### PR TITLE
ADD: glepnir/dashboard-nvim hlGroups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,5 +385,11 @@ fn oxocarbon() -> oxi::Result<()> {
     highlight!(HydraPink, 14, 17);
     highlight!(HydraHint, 17, 16);
 
+    // dashboard
+    highlight!(DashboardShortCut, 10, 17);
+    highlight!(DashboardHeader, 15, 17);
+    highlight!(DashboardCenter, 14, 17);
+    highlight!(DashboardFooter, 8, 17);
+
     Ok(())
 }


### PR DESCRIPTION
Added highlight groups for [dashboard](https://github.com/glepnir/dashboard-nvim)
![2022-08-02_18-08-1659445558](https://user-images.githubusercontent.com/91826760/182382264-c7debc3a-9088-4f13-9bab-77af8ff4bd86.png)
!