### PR TITLE
cargo update, fix for new nvim-oxi version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 [[package]]
 name = "nvim-oxi"
 version = "0.1.3"
-source = "git+https://github.com/noib3/nvim-oxi.git#3afc693ef16b45b19f255df2144688ed936f1aa9"
+source = "git+https://github.com/noib3/nvim-oxi.git#425e63db344655cb5f58d68579719736e228f245"
 dependencies = [
  "derive_builder",
  "libc",
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "nvim-types"
 version = "0.1.1"
-source = "git+https://github.com/noib3/nvim-oxi.git#3afc693ef16b45b19f255df2144688ed936f1aa9"
+source = "git+https://github.com/noib3/nvim-oxi.git#425e63db344655cb5f58d68579719736e228f245"
 dependencies = [
  "libc",
  "serde",
@@ -113,14 +113,14 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "oxi-module"
 version = "0.1.0"
-source = "git+https://github.com/noib3/nvim-oxi.git#3afc693ef16b45b19f255df2144688ed936f1aa9"
+source = "git+https://github.com/noib3/nvim-oxi.git#425e63db344655cb5f58d68579719736e228f245"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -202,18 +202,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ fn oxocarbon() -> oxi::Result<()> {
                 stringify!($hlname),
                 Some(
                     &SetHighlightOpts::builder()
-                        .fg(oxocarbon[$fgbase])
-                        .bg(oxocarbon[$bgbase])
+                        .foreground(oxocarbon[$fgbase])
+                        .background(oxocarbon[$bgbase])
                         .build(),
                 ),
             )?;
@@ -69,8 +69,8 @@ fn oxocarbon() -> oxi::Result<()> {
                 stringify!($hlname),
                 Some(
                     &SetHighlightOpts::builder()
-                        .fg(oxocarbon[$fgbase])
-                        .bg(oxocarbon[$bgbase])
+                        .foreground(oxocarbon[$fgbase])
+                        .background(oxocarbon[$bgbase])
                         .$key(true)
                         .build(),
                 ),
@@ -261,8 +261,8 @@ fn oxocarbon() -> oxi::Result<()> {
         "WinBar",
         Some(
             &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
+                .foreground("#a2a9b0")
+                .background(oxocarbon[0])
                 .build(),
         ),
     )?;
@@ -271,8 +271,8 @@ fn oxocarbon() -> oxi::Result<()> {
         "StatusPosition",
         Some(
             &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
+                .foreground("#a2a9b0")
+                .background(oxocarbon[0])
                 .build(),
         ),
     )?;
@@ -281,8 +281,8 @@ fn oxocarbon() -> oxi::Result<()> {
         "StatusNormal",
         Some(
             &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
+                .foreground("#a2a9b0")
+                .background(oxocarbon[0])
                 .underline(true)
                 .build(),
         ),
@@ -292,8 +292,8 @@ fn oxocarbon() -> oxi::Result<()> {
         "StatusCommand",
         Some(
             &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
+                .foreground("#a2a9b0")
+                .background(oxocarbon[0])
                 .underline(true)
                 .build(),
         ),
@@ -344,8 +344,8 @@ fn oxocarbon() -> oxi::Result<()> {
         "CmpItemAbbr",
         Some(
             &SetHighlightOpts::builder()
-                .fg("#adadad")
-                .bg(oxocarbon[17])
+                .foreground("#adadad")
+                .background(oxocarbon[17])
                 .build(),
         ),
     )?;


### PR DESCRIPTION
In newer version of nvim-oxi `SetHighlightOpts` structure changed names from `fg` and `bg` to `foreground` and `background`.