### PR TITLE
Fix fennel branch errors

### DIFF
--- a/fnl/oxocarbon/init.fnl
+++ b/fnl/oxocarbon/init.fnl
@@ -10,8 +10,8 @@
 ;;   Description:         Neovim Colorschemes based on base16 in fennel made with (hs)luv <3 
 ;;   Author:              https://github.com/shaunsingh
 
-(import-macros {: custom-set-face! : let!} :macros)
-(local {: blend-hex} (require :colorutils))
+(import-macros {: custom-set-face! : let!} :oxocarbon.macros)
+(local {: blend-hex} (require :oxocarbon.colorutils))
 
 ;; carbon palette 
 ;; (nyoom-module-p! nyoom.+carbon

--- a/fnl/oxocarbon/macros.fnl
+++ b/fnl/oxocarbon/macros.fnl
@@ -1,12 +1,15 @@
+(fn str? [s]
+  (= (type s) :string))
+
 (λ let-with-scope! [[scope] name value]
   (assert-compile (or (str? scope) (sym? scope)) "expected string or symbol for scope" scope)
-  (assert-compile (or (= :b (->str scope))
-                      (= :w (->str scope))
-                      (= :t (->str scope))
-                      (= :g (->str scope))) "expected scope to be either b, w, t or g" scope)
+  (assert-compile (or (= :b (tostring scope))
+                      (= :w (tostring scope))
+                      (= :t (tostring scope))
+                      (= :g (tostring scope))) "expected scope to be either b, w, t or g" scope)
   (assert-compile (or (str? name) (sym? name)) "expected string or symbol for name" name)
-  (let [name (->str name)
-        scope (->str scope)]
+  (let [name (tostring name)
+        scope (tostring scope)]
     `(tset ,(match scope
               :b 'vim.b
               :w 'vim.w
@@ -32,7 +35,7 @@
   ```"
    (match [...]
      [[scope] name value] (let-with-scope! [scope] name value)
-     [name value] (let-global! name value)
+     [name value] (let-with-scope! [:g] name value)
      _ (error "expected let! to have at least two arguments: name value")))
 
 (λ custom-set-face! [name attributes colors]
@@ -67,12 +70,12 @@
                                     :bold true})
   ```"
   (assert-compile (sym? name) "expected symbol for name" name)
-  (assert-compile (tbl? attributes) "expected table for attributes" attributes)
-  (assert-compile (tbl? colors) "expected colors for colors" colors)
-  (let [name (->str name)
+  (assert-compile (table? attributes) "expected table for attributes" attributes)
+  (assert-compile (table? colors) "expected colors for colors" colors)
+  (let [name (tostring name)
         definition (collect [_ attr (ipairs attributes)
                              :into colors]
-                     (->str attr) true)]
+                     (tostring attr) true)]
     `(vim.api.nvim_set_hl 0 ,name ,definition)))
 
 {: let!

--- a/lua/oxocarbon/init.lua
+++ b/lua/oxocarbon/init.lua
@@ -1,5 +1,5 @@
 local _2afile_2a = "fnl/oxocarbon/init.fnl"
-local _local_1_ = require("colorutils")
+local _local_1_ = require("oxocarbon.colorutils")
 local blend_hex = _local_1_["blend-hex"]
 local base00 = "#161616"
 local base06 = "#ffffff"

--- a/lua/oxocarbon/macros.fnl
+++ b/lua/oxocarbon/macros.fnl
@@ -1,12 +1,15 @@
+(fn str? [s]
+  (= (type s) :string))
+
 (λ let-with-scope! [[scope] name value]
   (assert-compile (or (str? scope) (sym? scope)) "expected string or symbol for scope" scope)
-  (assert-compile (or (= :b (->str scope))
-                      (= :w (->str scope))
-                      (= :t (->str scope))
-                      (= :g (->str scope))) "expected scope to be either b, w, t or g" scope)
+  (assert-compile (or (= :b (tostring scope))
+                      (= :w (tostring scope))
+                      (= :t (tostring scope))
+                      (= :g (tostring scope))) "expected scope to be either b, w, t or g" scope)
   (assert-compile (or (str? name) (sym? name)) "expected string or symbol for name" name)
-  (let [name (->str name)
-        scope (->str scope)]
+  (let [name (tostring name)
+        scope (tostring scope)]
     `(tset ,(match scope
               :b 'vim.b
               :w 'vim.w
@@ -32,7 +35,7 @@
   ```"
    (match [...]
      [[scope] name value] (let-with-scope! [scope] name value)
-     [name value] (let-global! name value)
+     [name value] (let-with-scope! [:g] name value)
      _ (error "expected let! to have at least two arguments: name value")))
 
 (λ custom-set-face! [name attributes colors]
@@ -67,12 +70,12 @@
                                     :bold true})
   ```"
   (assert-compile (sym? name) "expected symbol for name" name)
-  (assert-compile (tbl? attributes) "expected table for attributes" attributes)
-  (assert-compile (tbl? colors) "expected colors for colors" colors)
-  (let [name (->str name)
+  (assert-compile (table? attributes) "expected table for attributes" attributes)
+  (assert-compile (table? colors) "expected colors for colors" colors)
+  (let [name (tostring name)
         definition (collect [_ attr (ipairs attributes)
                              :into colors]
-                     (->str attr) true)]
+                     (tostring attr) true)]
     `(vim.api.nvim_set_hl 0 ,name ,definition)))
 
 {: let!

--- a/plugin/oxocarbon.vim
+++ b/plugin/oxocarbon.vim
@@ -1,3 +1,0 @@
-if has("nvim")
-  lua require("oxocarbon")
-endif

--- a/plugin/oxocarbon.vim
+++ b/plugin/oxocarbon.vim
@@ -1,3 +1,3 @@
 if has("nvim")
-  lua require("oxocarbon.main").init()
+  lua require("oxocarbon")
 endif


### PR DESCRIPTION
Fixes #23

- Fix lua requires
- Fix errors in macros.fnl
    - Add *str?* function
    - *tostring* instead of *->str*
    - *table?* instead of *tbl?*

Now the colorscheme is loaded automatically on install. Is this the intended behavior?