### PR TITLE
fix 0.8.0 crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,34 +81,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "libc"
-version = "0.2.134"
+name = "luajit-bindings"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "c74005abc71db092ff645cdf3afdc5447fcccab3193e72a10e5dce2da84c3d21"
+dependencies = [
+ "once_cell",
+ "thiserror",
+]
 
 [[package]]
-name = "nvim-oxi"
-version = "0.1.3"
+name = "nvim-api"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899991923a1eb342f025e64a242965292f7777927e0db11e3fa4b1839af0dcd4"
+checksum = "9c3f5770d973f41bb65a816163326131db29d861c96e895daba553e987bacd8f"
 dependencies = [
  "derive_builder",
- "libc",
+ "luajit-bindings",
  "nvim-types",
- "once_cell",
- "oxi-module",
  "serde",
  "serde_repr",
  "thiserror",
 ]
 
 [[package]]
-name = "nvim-types"
-version = "0.1.1"
+name = "nvim-oxi"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534f4dc1f66e13397d4772c7f15c683580a372ef57ebed50a60420bced4d43b8"
+checksum = "a5ce3af07cfe35f4cdbd82c590ebed5b8b9d167657b75e63836ba57e5d2d44fd"
 dependencies = [
- "libc",
+ "luajit-bindings",
+ "nvim-api",
+ "nvim-types",
+ "oxi-module",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "nvim-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32097b418c307b75730d49f8e446dc54dac28d05eafc300b835128baf7fc1042"
+dependencies = [
+ "luajit-bindings",
  "serde",
  "thiserror",
 ]
@@ -121,9 +137,9 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oxi-module"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924fe848ee5ac190fce77de453c152fa0c4ce34a41231c055c48e05a8fd88e7c"
+checksum = "6b9dc207b6986f418207799dbc61b12990f1dfa6bbbbee3d83cd0119d55f6033"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-nvim-oxi = "0.1.3"
+nvim-oxi = {version = "0.2.1", features=["neovim-0-8"]}
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-nvim-oxi = {version = "0.2.1", features=["neovim-0-8"]}
+nvim-oxi = {version = "0.2.1" }
 
+
+[features]
+"neovim-0-7" = ["nvim-oxi/neovim-0-7"]
+"neovim-0-8" = ["nvim-oxi/neovim-0-8"]
+"neovim-nightly" = ["nvim-oxi/neovim-nightly"]

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,21 @@
 
 set -e
 
-cargo build --release 
+NVIM_VERSION=$(nvim --version)
+NVIM_VERSION=$(echo "$NVIM_VERSION" | head -n 1 | sed -e 's/^NVIM v//')
+MINOR_VERSION=$(echo "$NVIM_VERSION" | cut -d '.' -f 2)
+
+if [ $MINOR_VERSION = "7" ]; then
+    cargo build --release --features neovim-0-7
+fi
+
+if [ $MINOR_VERSION = "8" ]; then
+    cargo build --release --features neovim-0-8
+fi
+
+if [ $MINOR_VERSION -gt 8 ]; then
+    cargo build --release --features neovim-nightly
+fi
 
 # Place the compiled library where Neovim can find it.
 mkdir -p lua

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@
 
 */
 
-use nvim_oxi::{self as oxi, api, opts::*};
-
+use nvim_oxi::api::opts::SetHighlightOpts;
+use nvim_oxi::{self as oxi, api};
 #[oxi::module]
 fn oxocarbon() -> oxi::Result<()> {
     api::set_option("termguicolors", true)?;
@@ -55,25 +55,21 @@ fn oxocarbon() -> oxi::Result<()> {
             api::set_hl(
                 0,
                 stringify!($hlname),
-                Some(
-                    &SetHighlightOpts::builder()
-                        .fg(oxocarbon[$fgbase])
-                        .bg(oxocarbon[$bgbase])
-                        .build(),
-                ),
+                &SetHighlightOpts::builder()
+                    .foreground(oxocarbon[$fgbase])
+                    .background(oxocarbon[$bgbase])
+                    .build(),
             )?;
         };
         ($hlname:expr, $fgbase:expr, $bgbase:expr, $key:ident) => {
             api::set_hl(
                 0,
                 stringify!($hlname),
-                Some(
-                    &SetHighlightOpts::builder()
-                        .fg(oxocarbon[$fgbase])
-                        .bg(oxocarbon[$bgbase])
-                        .$key(true)
-                        .build(),
-                ),
+                &SetHighlightOpts::builder()
+                    .foreground(oxocarbon[$fgbase])
+                    .background(oxocarbon[$bgbase])
+                    .$key(true)
+                    .build(),
             )?;
         };
     }
@@ -259,44 +255,36 @@ fn oxocarbon() -> oxi::Result<()> {
     api::set_hl(
         0,
         "WinBar",
-        Some(
-            &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
-                .build(),
-        ),
+        &SetHighlightOpts::builder()
+            .foreground("#a2a9b0")
+            .background(oxocarbon[0])
+            .build(),
     )?;
     api::set_hl(
         0,
         "StatusPosition",
-        Some(
-            &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
-                .build(),
-        ),
+        &SetHighlightOpts::builder()
+            .foreground("#a2a9b0")
+            .background(oxocarbon[0])
+            .build(),
     )?;
     api::set_hl(
         0,
         "StatusNormal",
-        Some(
-            &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
-                .underline(true)
-                .build(),
-        ),
+        &SetHighlightOpts::builder()
+            .foreground("#a2a9b0")
+            .background(oxocarbon[0])
+            .underline(true)
+            .build(),
     )?;
     api::set_hl(
         0,
         "StatusCommand",
-        Some(
-            &SetHighlightOpts::builder()
-                .fg("#a2a9b0")
-                .bg(oxocarbon[0])
-                .underline(true)
-                .build(),
-        ),
+        &SetHighlightOpts::builder()
+            .foreground("#a2a9b0")
+            .background(oxocarbon[0])
+            .underline(true)
+            .build(),
     )?;
 
     // telescope
@@ -342,12 +330,10 @@ fn oxocarbon() -> oxi::Result<()> {
     api::set_hl(
         0,
         "CmpItemAbbr",
-        Some(
-            &SetHighlightOpts::builder()
-                .fg("#adadad")
-                .bg(oxocarbon[17])
-                .build(),
-        ),
+        &SetHighlightOpts::builder()
+            .foreground("#adadad")
+            .background(oxocarbon[17])
+            .build(),
     )?;
 
     // nvimtree


### PR DESCRIPTION
closes #22 and other crashes related to neovim 0.8

This was done by bumping the version of `nvim-oxi` dependency.

To make this backwards compatible and not cause breaking changes to those who already have a working version, the package now incorporates the same features as `nvim-oxi`. As for the installer, `install.sh` script was also updated to grab neovim's current minor release and match it with the corresponding feature to compile appropriately.